### PR TITLE
Add a subcommand that delete device support

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/urfave/cli"
 	"github.com/yutailang0119/go-xccache-sweeper/sources/archives"
 	"github.com/yutailang0119/go-xccache-sweeper/sources/deriveddata"
+	"github.com/yutailang0119/go-xccache-sweeper/sources/devicesupport"
 )
 
 var (
@@ -47,6 +48,20 @@ func main() {
 				}
 
 				err = archives.SweepArchives()
+				return err
+			},
+		},
+		{
+			Name:  "devicesupport",
+			Usage: "Sweep Device Support. ~/Library/Developer/Xcode/*DeviceSupport",
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "all, a",
+					Usage: "force delete all",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				err := devicesupport.SweepDeviceSupports(c.Args().First(), c.Bool("all"))
 				return err
 			},
 		},

--- a/sources/devicesupport/deviceSupports.go
+++ b/sources/devicesupport/deviceSupports.go
@@ -1,0 +1,36 @@
+package devicesupport
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+type deviceSupports struct {
+	osName string
+}
+
+func (v deviceSupports) dirName() string {
+	return v.osName + " DeviceSupport"
+}
+
+func (v deviceSupports) path() string {
+	return xcodeFilesPath() + "/" + v.dirName()
+}
+
+func (v deviceSupports) versions() ([]deviceSupport, error) {
+	files, err := ioutil.ReadDir(v.path())
+	if err != nil {
+		return nil, err
+	}
+
+	var list []deviceSupport
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), ".") {
+			continue
+		}
+		path := v.path() + "/" + file.Name()
+		list = append(list, deviceSupport{v.osName, file.Name(), path})
+	}
+
+	return list, nil
+}

--- a/sources/devicesupport/deviceSupportsList.go
+++ b/sources/devicesupport/deviceSupportsList.go
@@ -1,0 +1,165 @@
+package devicesupport
+
+import (
+	"strconv"
+	"fmt"
+	"bufio"
+	"os"
+	"strings"
+)
+
+type deviceSupportsList struct {
+	iOS deviceSupports
+	watchOS deviceSupports
+	tvOS deviceSupports
+}
+
+func (v deviceSupportsList) osList(platform string) ([]deviceSupports, error) {
+	switch platform {
+	case "iOS":
+		return []deviceSupports{v.iOS}, nil
+	case "watchOS":
+		return []deviceSupports{v.watchOS}, nil
+	case "tvOS":
+		return []deviceSupports{v.tvOS}, nil
+	case "all":
+		var list []deviceSupports
+		iOSVersions, err := v.iOS.versions()
+		if err != nil {
+			return nil, err
+		}
+		if len(iOSVersions) != 0 {
+			list = append(list, v.iOS)
+		}
+
+		watchOSVersions, err := v.watchOS.versions()
+		if err != nil {
+			return nil, err
+		}
+		if len(watchOSVersions) != 0 {
+			list = append(list, v.watchOS)
+		}
+
+		tvOSVersion, err := v.tvOS.versions()
+		if err != nil {
+			return nil, err
+		}
+		if len(tvOSVersion) != 0 {
+			list = append(list, v.tvOS)
+		}
+
+		return list, nil
+	default:
+		return nil, fmt.Errorf("not found a platform: %s", platform)
+	}
+}
+
+func (v deviceSupportsList) allDeviceSupports(platform string) ([]deviceSupport, error) {
+	osList, err := v.osList(platform)
+	if err != nil {
+		return nil, err
+	}
+	var all []deviceSupport
+	for _, supports := range  osList {
+		versions, err := supports.versions()
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, versions...)
+	}
+	return  all, nil
+}
+
+func (v deviceSupportsList) deleteAll(platform string) error {
+	osList, err := v.osList(platform)
+	if err != nil {
+		return err
+	}
+	if osList == nil {
+		fmt.Println("not found a platform: ", platform)
+		return nil
+	}
+	allDeviceSupports, err := v.allDeviceSupports(platform)
+	if err != nil {
+		return err
+	}
+	if len(allDeviceSupports) == 0 {
+		fmt.Println("not found DeviceSupport: ", platform)
+		return nil
+	}
+	message := "Deleted: "
+	for _, supports := range osList {
+		versions, err := supports.versions()
+		if err != nil {
+			return err
+		}
+		message += "\n - " + supports.osName
+		for _, support := range versions {
+			message += "\n    - " + support.version
+			err = os.RemoveAll(support.path)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	fmt.Println(message)
+
+	return nil
+}
+
+func (v deviceSupportsList) askDelete(platform string) error {
+	osList, err := v.osList(platform)
+	if err != nil {
+		return err
+	}
+
+	allDeviceSupports, err := v.allDeviceSupports(platform)
+	if err != nil {
+		return err
+	}
+	if len(allDeviceSupports) == 0 {
+		fmt.Println("not found DeviceSupport: ", platform)
+		return nil
+	}
+
+	message := "Which do you want to delete? Please select index"
+	count := 0
+	for _, supports := range osList {
+		versions, err := supports.versions()
+		if err != nil {
+			return err
+		}
+		message += "\n" + supports.osName
+		for _, version := range versions {
+			message += "\n " + strconv.Itoa(count) + ": " + version.description()
+			count++
+		}
+	}
+	fmt.Println(message)
+
+	reader := bufio.NewReader(os.Stdin)
+	inputIndex, _ := reader.ReadString('\n')
+	inputIndex = strings.TrimSuffix(inputIndex, "\n")
+	index, err := strconv.Atoi(inputIndex)
+	if err != nil {
+		fmt.Println("Please input number")
+		return v.askDelete(platform)
+	}
+
+	target := allDeviceSupports[index]
+	err = os.RemoveAll(target.path)
+	if err != nil {
+		return  err
+	}
+
+	fmt.Println("Deleted: ", target.description())
+
+	allDeviceSupports, _ = v.allDeviceSupports(platform)
+	if len(allDeviceSupports) == 0 {
+		fmt.Println("Complete all deleted 🎉")
+		return nil
+	}
+
+	return v.askDelete(platform)
+}

--- a/sources/devicesupport/devicesupport.go
+++ b/sources/devicesupport/devicesupport.go
@@ -1,0 +1,11 @@
+package devicesupport
+
+type deviceSupport struct {
+	osName string
+	version string
+	path    string
+}
+
+func (v deviceSupport) description() string {
+	return v.osName + "/" + v.version
+}

--- a/sources/devicesupport/sweep_devicesupport.go
+++ b/sources/devicesupport/sweep_devicesupport.go
@@ -1,0 +1,43 @@
+package devicesupport
+
+import (
+	"strings"
+	"os/user"
+)
+
+func xcodeFilesPath() string {
+	usr, _ := user.Current()
+	return strings.Replace("~/Library/Developer/Xcode", "~", usr.HomeDir, 1)
+}
+
+// SweepDeviceSupports sweep ~/Library/Developer/Xcode/*DeviceSupport
+// platform: "iOS", "watchOS", "tvOS" and "all"
+// isAll: force delete all
+func SweepDeviceSupports(platform string, isAll bool) error {
+
+	if platform == "" {
+		platform = "all"
+	}
+
+	iOS := deviceSupports{"iOS"}
+	watchOS := deviceSupports{"watchOS"}
+	tvOS := deviceSupports{"tvOS"}
+	list := deviceSupportsList{iOS: iOS, watchOS: watchOS, tvOS: tvOS}
+
+	if isAll {
+		err := list.deleteAll(platform)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	err := list.askDelete(platform)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}


### PR DESCRIPTION
Support OS of iOS, watchOS, tvOS

```shell
xccache-sweeper devicesupport -help
NAME:
   xccache-sweeper devicesupport - Sweep Device Support. ~/Library/Developer/Xcode/*DeviceSupport

USAGE:
   xccache-sweeper devicesupport [command options] [arguments...]

OPTIONS:
   --all, -a  force delete all
```