### PR TITLE
Fix error when devicesupport is missing

### DIFF
--- a/lib/devicesupport/deviceSupports.go
+++ b/lib/devicesupport/deviceSupports.go
@@ -2,6 +2,7 @@ package devicesupport
 
 import (
 	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -18,12 +19,21 @@ func (v deviceSupports) path() string {
 }
 
 func (v deviceSupports) versions() ([]deviceSupport, error) {
-	files, err := ioutil.ReadDir(v.path())
+	path := v.path()
+
+	var list []deviceSupport
+
+	exist, err := exists(path)
+
+	if !exist {
+		return list, nil
+	}
+
+	files, err := ioutil.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
 
-	var list []deviceSupport
 	for _, file := range files {
 		if strings.HasPrefix(file.Name(), ".") {
 			continue
@@ -33,4 +43,15 @@ func (v deviceSupports) versions() ([]deviceSupport, error) {
 	}
 
 	return list, nil
+}
+
+func exists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, err
 }

--- a/lib/devicesupport/deviceSupports.go
+++ b/lib/devicesupport/deviceSupports.go
@@ -23,9 +23,9 @@ func (v deviceSupports) versions() ([]deviceSupport, error) {
 
 	var list []deviceSupport
 
-	exist, err := exists(path)
+	isExist, _ := exists(path)
 
-	if !exist {
+	if !isExist {
 		return list, nil
 	}
 
@@ -50,8 +50,10 @@ func exists(path string) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
+
 	if os.IsNotExist(err) {
 		return false, nil
 	}
+
 	return true, err
 }


### PR DESCRIPTION
The command was failing when the devicesupport directory (e.g. watchOS, tvOS, etc) was missing.